### PR TITLE
Add support for negative balances on totals page

### DIFF
--- a/streamlit_frontend/frontend.py
+++ b/streamlit_frontend/frontend.py
@@ -136,10 +136,10 @@ def totals_page():
             values = {}
             with open(filename, 'r') as f:
                 for line in f:
-                    res = re.search(r".+\s+balance\s+\w+\:([\w\:]+)\s+([\d\.]+)\s+(\w+).*", line)
+                    res = re.search(r".+\s+balance\s+\w+\:([\w\:]+)\s+([-\d\.]+)\s+(\w+).*", line)
                     if res:
                         values[(res.group(1), res.group(3))] = float(res.group(2))
-                    res_val = re.search(r".+\s+\"valuation\"\s+\w+\:([\w\:]+)\s+([\d\.]+)\s+(\w+).*", line)
+                    res_val = re.search(r".+\s+\"valuation\"\s+\w+\:([\w\:]+)\s+([-\d\.]+)\s+(\w+).*", line)
                     if res_val:
                         values[(res_val.group(1), res_val.group(3))] = float(res_val.group(2))
         else:


### PR DESCRIPTION
Liabilities that you owe (such as credit card debt, loans) have negative balances. When creating accounts with negative balances using Lazy-Beancount's Totals screen, it would initially allow input for negative values. However, on reloading the page, it would not find any balance entries that had negative values. Saving the file again would wipe these entries out.

This patch fixes the regex so that the streamlit frontend can find and display negative values.